### PR TITLE
Fixes to command, open file, enable logging pref

### DIFF
--- a/OP_VHCAD_main.py
+++ b/OP_VHCAD_main.py
@@ -85,7 +85,7 @@ class VHACD_OT_VHACD(Operator):
         default=1,
         min=0.001,
         max=10
-    )   
+    )
 
     maxRecursionDepth: IntProperty(
         name='Maximum recursion Depth',
@@ -183,9 +183,14 @@ class VHACD_OT_VHACD(Operator):
             # change cd to the data path + use integers for the bool values (Pascal case True/False is not valid)
             cmd_line = (f'cd "{data_path}" && "{vhacd_path}" "{obj_filename}" -h {self.maxConvexHull} -r {self.voxelResolution} -e {self.volumeErrorPercent} -d {self.maxRecursionDepth} -s {int(self.shrinkwrapOutput)} -f {self.fillMode} -v {self.maxHullVertCount} -a {int(self.runAsync)} -l {self.minEdgeLength} -o obj -p {int(self.optimalSplit)}')
 
+            # activate logging messages
+            if prefs.enable_logging:
+                cmd_line += f" -g 1"
+
             print(f'Running V-HACD...\n{cmd_line}\n')
             vhacd_process = Popen(cmd_line, bufsize=-1, close_fds=True, shell=True)
             vhacd_process.wait()
+
             # read file in specified data path
             from os import path
             bpy.ops.import_scene.obj(filepath=data_path + "\decomp.obj")
@@ -249,7 +254,7 @@ class VHACD_OT_VHACD(Operator):
 ## Registration
 def menu_func(self, context):
     self.layout.operator(VHACD_OT_VHACD.bl_idname)
-    self.layout.operator(VHACD_OT_SelectHulls.bl_idname)            
+    self.layout.operator(VHACD_OT_SelectHulls.bl_idname)
 
 classes = (
 VHACD_OT_VHACD,
@@ -257,7 +262,7 @@ VHACD_OT_SelectHulls,
 )
 
 def register():
-    for cl in classes:  
+    for cl in classes:
         bpy.utils.register_class(cl)
 
     bpy.types.VIEW3D_MT_object.append(menu_func)

--- a/OP_VHCAD_main.py
+++ b/OP_VHCAD_main.py
@@ -180,13 +180,17 @@ class VHACD_OT_VHACD(Operator):
             ob.select_set(True)
             bpy.ops.export_scene.obj(filepath=obj_filename, use_selection=True)
 
-            cmd_line = (f'"{vhacd_path}" "{obj_filename}" -h {self.maxConvexHull} -r {self.voxelResolution} - {self.volumeErrorPercent} -d {self.maxRecursionDepth} -s {self.shrinkwrapOutput} -f {self.fillMode} -v {self.maxHullVertCount} -a {self.runAsync} -l {self.minEdgeLength} -o obj -p {self.optimalSplit}')
+            # change cd to the data path + use integers for the bool values (Pascal case True/False is not valid)
+            cmd_line = (f'cd "{data_path}" && "{vhacd_path}" "{obj_filename}" -h {self.maxConvexHull} -r {self.voxelResolution} -e {self.volumeErrorPercent} -d {self.maxRecursionDepth} -s {int(self.shrinkwrapOutput)} -f {self.fillMode} -v {self.maxHullVertCount} -a {int(self.runAsync)} -l {self.minEdgeLength} -o obj -p {int(self.optimalSplit)}')
 
             print(f'Running V-HACD...\n{cmd_line}\n')
             vhacd_process = Popen(cmd_line, bufsize=-1, close_fds=True, shell=True)
             vhacd_process.wait()
-    
-            bpy.ops.import_scene.obj(filepath=get_last_generated_file_path())
+            # read file in specified data path
+            from os import path
+            bpy.ops.import_scene.obj(filepath=data_path + "\decomp.obj")
+
+            #bpy.ops.import_scene.obj(filepath=get_last_generated_file_path())
             imported = bpy.context.selected_objects
             new_objects.extend(imported)
 

--- a/__init__.py
+++ b/__init__.py
@@ -30,7 +30,7 @@ bl_info = {
 
 import bpy
 from bpy.types import AddonPreferences
-from bpy.props import StringProperty
+from bpy.props import StringProperty, BoolProperty
 from tempfile import gettempdir
 from . import OP_VHCAD_main
 
@@ -60,12 +60,19 @@ class VHACD_blender_prefs(AddonPreferences):
         default='?_hull_#',
     )
 
+    enable_logging: BoolProperty(
+        name='Enable V-HACD logging',
+        description='Activate V-HACD logging (-g option set in CMD)',
+        default=True,
+    )
+
     def draw(self, context):
         layout = self.layout
         col = layout.column()
         col.prop(self, 'executable_path')
         col.prop(self, 'data_path')
         col.prop(self, 'name_template')
+        col.prop(self, 'enable_logging')
 
 classes = (
     VHACD_blender_prefs,


### PR DESCRIPTION
Hey! Nice work on the updates. I had to do some tweaks so I leave them here in case you are interested:

* "True" "False" booleans in the command were not valid, either use lowercase or cast to interested. Default values were being used instead, there were warnings in the log.
* In my case, `decomp.obj` was being saved to the blender.exe directory and then `get_last_generated_file_path()` was not finding it. I just used the same command to set cd beforhand. I picked `data_path` from preferences, this ensures a global path.
* I added a preference to activate VHACD logging messages.

Thanks
